### PR TITLE
Add .runfile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Runfile - If Rake and Docopt had a baby
-=======================================
+==================================================
 
 [![Gem Version](https://badge.fury.io/rb/runfile.svg)](http://badge.fury.io/rb/runfile)
 [![Build Status](https://travis-ci.org/DannyBen/runfile.svg?branch=master)](https://travis-ci.org/DannyBen/runfile)
@@ -25,21 +25,22 @@ You create a `Runfile`, and execute commands with
 
 ---
 
-## Install ##
+Install
+--------------------------------------------------
 
 	$ gem install runfile
 
 
-
-## Quick Start ##
+Quick Start
+--------------------------------------------------
 
 	$ run make       # create a new Runfile
 	$ run --help     # show the usage patterns
 	$ vi Runfile     # edit the Runfile
 
 
-
-## Example ##
+Example
+--------------------------------------------------
 
 The most minimal `Runfile` looks like this:
 
@@ -85,8 +86,8 @@ Options:
 ```
 
 
-
-## Runfile per project or global Runfiles ##
+Runfile per project or global Runfiles
+--------------------------------------------------
 
 In addition to the per project `Runfile` files, it is also possible to 
 create global runfiles that are accessible to you only or to anybody on 
@@ -105,8 +106,8 @@ for global (named) runfiles.
 Read more in the [Runfile Location and Filename wiki page](https://github.com/DannyBen/runfile/wiki/Runfile-Location-and-Filename)
 
 
-
-## Documentation ##
+Documentation
+--------------------------------------------------
 
 - [Learn by Example](https://github.com/DannyBen/runfile/tree/master/examples)
 - [Runfile Command Reference](https://github.com/DannyBen/runfile/wiki/Runfile-Command-Reference)

--- a/examples/r_exec/Runfile
+++ b/examples/r_exec/Runfile
@@ -25,7 +25,7 @@ action :piddir do
 end
 
 action :log do
-  run_bg "pwd", log: 'pwd.log'
+  run_bg "echo 'logged'", log: 'log.log'
 end
 
 usage  "sleep [--stop]"

--- a/examples/s_settings/.runfile
+++ b/examples/s_settings/.runfile
@@ -1,0 +1,4 @@
+---
+# A settings YAML file to define folder to search in
+
+folder: commands

--- a/examples/s_settings/commands/beer.runfile
+++ b/examples/s_settings/commands/beer.runfile
@@ -1,0 +1,6 @@
+name    "Beer"
+summary "A sample Runfile"
+
+action :drink do
+  say "Drink Beer"
+end

--- a/examples/s_settings/commands/pizza.runfile
+++ b/examples/s_settings/commands/pizza.runfile
@@ -1,0 +1,6 @@
+name    "Pizza"
+summary "A sample Runfile"
+
+action :order do
+  say "Order Pizza"
+end

--- a/features/n_exec.feature
+++ b/features/n_exec.feature
@@ -33,10 +33,10 @@ Scenario: "Execute a background job storing pid in another folder"
     And the file "pidfile.pid" should not exist
 
 Scenario: "Execute a background job and direct output to a log"
-  Given the file "pwd.log" does not exist
+  Given the file "log.log" does not exist
    When I run "run log"
-   Then the file "pwd.log" should exist
-    And the file "pwd.log" should match "runfile/examples/r_exec"
+   Then the file "log.log" should exist
+    And the file "log.log" should match "logged"
 
 Scenario: "Stop a background job"
    When I run "run sleep"

--- a/features/o_settings.feature
+++ b/features/o_settings.feature
@@ -1,0 +1,20 @@
+Feature: Settings File
+  In order to allow multiple runfiles per project
+  Users can have a ".runfile" file to configure search folder
+  Like "folder: lib/commands"
+
+Background:
+  Given I am in the "examples/s_settings" folder
+
+Scenario: See list of runfiles in the configured folder
+   When I run "run"
+   Then the output should match "run beer"
+    And the output should match "run pizza"
+
+Scenario: See usage of a runfile in the folder
+   When I run "run pizza"
+   Then the output should match "run pizza order"
+
+Scenario: Execute a runfile in the folder
+   When I run "run pizza order"
+   Then the output should be "Order Pizza"

--- a/features/o_settings.feature
+++ b/features/o_settings.feature
@@ -18,3 +18,7 @@ Scenario: See usage of a runfile in the folder
 Scenario: Execute a runfile in the folder
    When I run "run pizza order"
    Then the output should be "Order Pizza"
+
+Scenario: Execute run bang in a folder with settings
+   When I run "run!"
+   Then the output should match "Tip: Type 'run make' or 'run make name'..."

--- a/lib/runfile.rb
+++ b/lib/runfile.rb
@@ -5,5 +5,6 @@ require 'runfile/action'
 require 'runfile/runner'
 require 'runfile/dsl'
 require 'runfile/util'
+require 'runfile/settings'
 
 require 'runfile/extensions/exec'

--- a/lib/runfile/runfile_helper.rb
+++ b/lib/runfile/runfile_helper.rb
@@ -37,6 +37,10 @@ module Runfile
       return false
     end
 
+    def purge_settings
+      @settings = OpenStruct.new
+    end
+
     private
 
     # Create a new runfile in the current directory. We can either

--- a/lib/runfile/runfile_helper.rb
+++ b/lib/runfile/runfile_helper.rb
@@ -67,7 +67,7 @@ module Runfile
 
     # Show some helpful tips, and a list of available runfiles
     def show_make_help(runfiles, compact=false)
-      say "!txtpur!Runfile engine v#{Runfile::VERSION}"
+      say "!txtpur!Runfile engine v#{Runfile::VERSION}" unless compact
       if runfiles.size < 3 and !compact
         say "\nTip: Type '!txtblu!run make!txtrst!' or '!txtblu!run make name!txtrst!' to create a runfile.\nFor global access, place !txtblu!named.runfiles!txtrst! in ~/runfile/ or in /etc/runfile/."
       end
@@ -88,7 +88,7 @@ module Runfile
       # If there is a '.runfile' settings file with a folder definition
       # in it, use it. Otherwise, search globally.
       if settings.folder
-        ["lib/#{subdirs}"]
+        ["#{settings.folder}/#{subdirs}"]
       else
         [Dir.pwd, "#{Dir.home}/runfile/#{subdirs}", "/etc/runfile/#{subdirs}"]
       end

--- a/lib/runfile/runfile_helper.rb
+++ b/lib/runfile/runfile_helper.rb
@@ -31,8 +31,9 @@ module Runfile
         runfile and return runfile
       end
 
-      # if we are here, offer some help and advice
-      show_make_help runfiles
+      # if we are here, offer some help and advice and show a list
+      # of possible runfiles to run.
+      show_make_help runfiles, settings.folder
       return false
     end
 
@@ -53,7 +54,7 @@ module Runfile
       end
     end
 
-    # Find all *.runfile files in in our search difrectories
+    # Find all *.runfile files in our search difrectories
     def find_runfiles
       result = []
       dirs = runfile_folders
@@ -65,14 +66,16 @@ module Runfile
     end
 
     # Show some helpful tips, and a list of available runfiles
-    def show_make_help(runfiles)
+    def show_make_help(runfiles, compact=false)
       say "!txtpur!Runfile engine v#{Runfile::VERSION}"
-      runfiles.size < 3 and say "\nTip: Type '!txtblu!run make!txtrst!' or '!txtblu!run make name!txtrst!' to create a runfile.\nFor global access, place !txtblu!named.runfiles!txtrst! in ~/runfile/ or in /etc/runfile/."
+      if runfiles.size < 3 and !compact
+        say "\nTip: Type '!txtblu!run make!txtrst!' or '!txtblu!run make name!txtrst!' to create a runfile.\nFor global access, place !txtblu!named.runfiles!txtrst! in ~/runfile/ or in /etc/runfile/."
+      end
       if runfiles.empty? 
         say "\n!txtred!Runfile not found."
       else
         say ""
-        say_runfile_list runfiles
+        say_runfile_list runfiles, compact
       end
     end
 
@@ -81,7 +84,14 @@ module Runfile
       # This trick allows searching in subfolders recursively, including
       # one level of symlinked folder
       subdirs = '**{,/*/**}'
-      [Dir.pwd, "#{Dir.home}/runfile/#{subdirs}", "/etc/runfile/#{subdirs}"]
+      
+      # If there is a '.runfile' settings file with a folder definition
+      # in it, use it. Otherwise, search globally.
+      if settings.folder
+        ["lib/#{subdirs}"]
+      else
+        [Dir.pwd, "#{Dir.home}/runfile/#{subdirs}", "/etc/runfile/#{subdirs}"]
+      end
     end
     
     # [UNUSED] Same as runfile_folders, but including PATH
@@ -92,18 +102,26 @@ module Runfile
     end
 
     # Output the list of available runfiles
-    def say_runfile_list(runfiles)
+    def say_runfile_list(runfiles, compact=false)
       runfile_paths = runfiles.map { |f| File.dirname f }
       max = runfile_paths.max_by(&:length).size
       width, height = detect_terminal_size
       runfiles.each do |f|
         f[/([^\/]+).runfile$/]
         command  = "run #{$1}"
-        spacer_size = width - max - command.size - 6
-        spacer_size = [1, spacer_size].max
-        spacer = '.' * spacer_size
-        say "  !txtgrn!#{command}!txtrst! #{spacer} #{File.dirname f}"
+        if compact
+          say "  !txtgrn!#{command}!txtrst!"
+        else
+          spacer_size = width - max - command.size - 6
+          spacer_size = [1, spacer_size].max
+          spacer = '.' * spacer_size
+          say "  !txtgrn!#{command}!txtrst! #{spacer} #{File.dirname f}"
+        end
       end
+    end
+
+    def settings
+      @settings ||= Settings.new.as_struct
     end
 
   end

--- a/lib/runfile/runner.rb
+++ b/lib/runfile/runner.rb
@@ -35,6 +35,7 @@ module Runfile
 
     # Load and execute a Runfile call.
     def execute(argv, filename='Runfile')
+      @ignore_settings = !filename
       filename and File.file?(filename) or handle_no_runfile argv
       begin
         load filename
@@ -140,6 +141,7 @@ module Runfile
     # on our part, or the name of a runfile to execute.
     def handle_no_runfile(argv)
       maker = RunfileHelper.new
+      maker.purge_settings if @ignore_settings
       runfile = maker.handle argv
       if runfile
         @superspace = argv[0]

--- a/lib/runfile/runner.rb
+++ b/lib/runfile/runner.rb
@@ -30,8 +30,7 @@ module Runfile
 
     # Return a singleton Runner instance.
     def self.instance
-      @@instance = self.new if @@instance.nil?
-      @@instance
+      @@instance ||= self.new
     end
 
     # Load and execute a Runfile call.

--- a/lib/runfile/settings.rb
+++ b/lib/runfile/settings.rb
@@ -1,0 +1,27 @@
+require 'ostruct'
+require 'yaml'
+
+module Runfile
+
+  # The Settings class handles '.runfile' YAML config files.
+  # If found in the current directory, we will use their content.
+  class Settings
+    def initialize
+    end
+
+    def as_struct
+      OpenStruct.new settings
+    end
+
+    private
+
+    def settings
+      @settings ||= settings!
+    end
+
+    def settings!
+      File.file?('.runfile') ? YAML.load_file('.runfile') : {}
+    end
+  end
+
+end

--- a/lib/runfile/version.rb
+++ b/lib/runfile/version.rb
@@ -1,3 +1,3 @@
 module Runfile
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
Add support for `.runfile` config to address #7 

At this time, the only setting it handles is the `folder` setting.
When this file is found in the local folder, then we will use the folder it defines as the folder for named runfiles.

In addition, the `run!` bin will continue to work as usual and ignore any local settings.

