### PR TITLE
Improve usage file list when using .runfile settings

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -16,3 +16,16 @@ action :clicumber do
   exec "curl -o '#{file}' #{url}"
 end
 
+help   "Rename (toggle) the ~/runfile folder so we can run tests"
+action :pretest do
+  if File.directory? "#{Dir.home}/runfile"
+    File.rename "#{Dir.home}/runfile", "#{Dir.home}/runfile_"
+    say "Global runfiles !txtred!disabled"
+  elsif File.directory? "#{Dir.home}/runfile_"
+    File.rename "#{Dir.home}/runfile_", "#{Dir.home}/runfile"
+    say "Global runfiles !txtgrn!enabled"
+  end
+
+end
+
+

--- a/examples/s_settings/.runfile
+++ b/examples/s_settings/.runfile
@@ -4,6 +4,10 @@
 # Define the folder where *.runfile files reside
 folder: commands
 
-# Optionally, load this file before loading any other runfile
+# Optional: File to load before any runfile
 # Consider this your "helper" file.
 helper: helper.rb
+
+# Optional: Message to show before the list of files
+# This string supports color markers
+intro: "!txtgrn!My Command Line"

--- a/features/n_exec.feature
+++ b/features/n_exec.feature
@@ -35,6 +35,7 @@ Scenario: "Execute a background job storing pid in another folder"
 Scenario: "Execute a background job and direct output to a log"
   Given the file "log.log" does not exist
    When I run "run log"
+    And I wait "1" second
    Then the file "log.log" should exist
     And the file "log.log" should match "logged"
 

--- a/features/o_settings.feature
+++ b/features/o_settings.feature
@@ -8,8 +8,8 @@ Background:
 
 Scenario: See list of runfiles in the configured folder
    When I run "run"
-   Then the output should match "run beer"
-    And the output should match "run pizza"
+   Then the output should match "Usage: run <file>"
+    And the output should match "beer.*pizza"
 
 Scenario: See usage of a runfile in the folder
    When I run "run pizza"
@@ -26,3 +26,7 @@ Scenario: Execute run bang in a folder with settings
 Scenario: Autoload helper file
    When I run "run loadchecker check"
    Then the output should be "This message came from helper.rb"
+
+Scenario: Show intro line
+   When I run "run"
+   Then the output should match "My Command Line"

--- a/features/step_definitions/clicumber.rb
+++ b/features/step_definitions/clicumber.rb
@@ -73,6 +73,11 @@ When(/^I go into the "([^"]*)" (?:folder|dir|directory)$/) do |dir|
   Dir.chdir dir
 end
 
+## When...wait
+When(/^I wait (?:for )?"([^"]*)" seconds?$/) do |seconds|
+  sleep seconds.to_f
+end
+
 ## Then...output
 
 Then(/^the (error )?output should (not )?be like "([^"]*)"$/) do |stderr, negate, file|

--- a/lib/runfile/docopt_helper.rb
+++ b/lib/runfile/docopt_helper.rb
@@ -29,7 +29,7 @@ module Runfile
     # Generate a document based on all the actions, help messages
     # and options we have collected from the Runfile DSL.
     def docopt
-      width, height = detect_terminal_size
+      width = detect_terminal_size[0]
       doc = []
       doc << (@version ? "#{@name} #{@version}" : "#{@name}")
       doc << "#{@summary}" if @summary

--- a/lib/runfile/runfile_helper.rb
+++ b/lib/runfile/runfile_helper.rb
@@ -123,11 +123,14 @@ module Runfile
 
     # Output the list of available runfiles without filename
     def say_runfile_usage(runfiles)
-      runfiles.each do |f|
-        f[/([^\/]+).runfile$/]
-        command  = "run #{$1}"
-        say "  !txtgrn!#{command}!txtrst!"
-      end
+      namelist = runfiles.map {|f| /([^\/]+).runfile$/.match(f)[1] }
+      width = detect_terminal_size[0]
+      max = namelist.max_by(&:length).length
+      message = "  " + namelist.map {|f| f.ljust max+1 }.join(' ')
+      
+      say "#{settings.intro}\n" if settings.intro
+      say "Usage: run <file>"
+      say word_wrap(message, width)
     end
 
   end


### PR DESCRIPTION
- when using `.runfile`, file list will be shown with columns
- add `intro:` setting to `.runfile`
- add `pretest` command to development runfile, to rename `~/runfile`