### PR TITLE
Add config block to Runfile::Exec

### DIFF
--- a/examples/r_exec/Runfile
+++ b/examples/r_exec/Runfile
@@ -41,6 +41,15 @@ action :error do
   stop_bg 'no-such-pid-file'
 end
 
+action :'block-config' do
+  Exec.setup do |config|
+    config.pid_dir = 'what-a-lovely-folder'
+  end
+  say "pid_dir = #{Exec.pid_dir}"
+
+  Exec.pid_dir = nil # just reset to default for other tests
+end
+
 # Optional Hooks
 
 # Will be called before each call to run, run! and run_bg

--- a/examples/r_exec/Runfile
+++ b/examples/r_exec/Runfile
@@ -41,6 +41,12 @@ action :error do
   stop_bg 'no-such-pid-file'
 end
 
+action :quiet do
+  Exec.quiet = true
+  run "echo quietly"
+  Exec.quiet = false
+end
+
 action :'block-config' do
   Exec.setup do |config|
     config.pid_dir = 'what-a-lovely-folder'

--- a/features/n_exec.feature
+++ b/features/n_exec.feature
@@ -25,7 +25,6 @@ Scenario: "Execute a background job with a given pid alias"
     And the file "ls.pid" should exist
     And the file "ls.pid" should match "\d+"
 
-@current
 Scenario: "Execute a background job storing pid in another folder"
   Given the file "tmp/pidfile.pid" does not exist
    When I run "run piddir"
@@ -49,4 +48,8 @@ Scenario: "Stop a background job"
 Scenario: "Stop a non existing background job"
    When I run "run error"
    Then the output should say "PID file not found"
+
+Scenario: "Configure with a block"
+   When I run "run block-config"
+   Then the output should say "pid_dir = what-a-lovely-folder"
 

--- a/features/n_exec.feature
+++ b/features/n_exec.feature
@@ -53,3 +53,6 @@ Scenario: "Configure with a block"
    When I run "run block-config"
    Then the output should say "pid_dir = what-a-lovely-folder"
 
+Scenario: "Run without showing the command"
+   When I run "run quiet"
+   Then the output should match "BEFORE echo quietly\nquietly\nAFTER echo quietly"

--- a/features/n_exec.feature
+++ b/features/n_exec.feature
@@ -25,6 +25,7 @@ Scenario: "Execute a background job with a given pid alias"
     And the file "ls.pid" should exist
     And the file "ls.pid" should match "\d+"
 
+@current
 Scenario: "Execute a background job storing pid in another folder"
   Given the file "tmp/pidfile.pid" does not exist
    When I run "run piddir"

--- a/lib/runfile/extensions/exec.rb
+++ b/lib/runfile/extensions/exec.rb
@@ -5,12 +5,12 @@
 
 module Runfile
   module Exec
-    def self.pid_dir=(dir)
-      @@pid_dir = dir
-    end
+    class << self
+      attr_accessor :pid_dir
 
-    def self.pid_dir
-      @@pid_dir
+      def setup
+        yield self
+      end
     end
 
     # Run a command, wait until it is done and continue
@@ -66,10 +66,8 @@ module Runfile
       @after_run_block = block
     end
 
-    private
-
     def pid_dir
-      defined?(@@pid_dir) ? @@pid_dir : nil
+      defined?(Exec.pid_dir) ? Exec.pid_dir : nil
     end
 
     def pidfile(pid)

--- a/lib/runfile/extensions/exec.rb
+++ b/lib/runfile/extensions/exec.rb
@@ -6,7 +6,7 @@
 module Runfile
   module Exec
     class << self
-      attr_accessor :pid_dir
+      attr_accessor :pid_dir, :quiet
 
       def setup
         yield self
@@ -17,7 +17,7 @@ module Runfile
     def run(cmd)
       cmd = @before_run_block.call(cmd) if @before_run_block
       return false unless cmd
-      say "!txtgrn!> #{cmd}"
+      say "!txtgrn!> #{cmd}" unless Exec.quiet
       system cmd
       @after_run_block.call(cmd) if @after_run_block
     end
@@ -26,7 +26,7 @@ module Runfile
     def run!(cmd)
       cmd = @before_run_block.call(cmd) if @before_run_block
       return false unless cmd
-      say "!txtgrn!> #{cmd}"
+      say "!txtgrn!> #{cmd}" unless Exec.quiet
       exec cmd
     end
 
@@ -36,7 +36,7 @@ module Runfile
       cmd = @before_run_block.call(cmd) if @before_run_block
       return false unless cmd
       full_cmd = "exec #{cmd} >#{log} 2>&1"
-      say "!txtgrn!> #{full_cmd}"
+      say "!txtgrn!> #{full_cmd}" unless Exec.quiet
       process = IO.popen "exec #{cmd} >#{log} 2>&1"
       File.write pidfile(pid), process.pid if pid
       @after_run_block.call(cmd) if @after_run_block
@@ -52,7 +52,7 @@ module Runfile
         File.delete file
         run "kill -s TERM #{pid}"
       else
-        say "!txtred!PID file not found."
+        say "!txtred!PID file not found." unless Exec.quiet
       end
     end
 


### PR DESCRIPTION
This PR adds several configuration options to `Runfile::Exec`:

1. Ability to silence the command echoes with `Exec.quiet = true`
2. Ability to configure with a block:
```ruby
Exec.setup do |config|
  config.pid_dir = 'tmp'
  config.quiet = true
end
```

  