### PR TITLE
DSL Change: Rename call to execute

### DIFF
--- a/examples/i_crosscall/Runfile
+++ b/examples/i_crosscall/Runfile
@@ -16,9 +16,9 @@ end
 # this action calls other actions, including one in a different
 # command namespace ("eat")
 action :exercise do
-  call "jump --high --twice"
-  call "jog"
-  call "eat cake"
+  execute "jump --high --twice"
+  execute "jog"
+  execute "eat cake"
 end
 
 command "eat"
@@ -28,8 +28,8 @@ action :cake do
 end
 
 action :'two-cakes' do
-  call "eat cake"
-  call "eat cake"
-  call "jog"
+  execute "eat cake"
+  execute "eat cake"
+  execute "jog"
 end
 

--- a/lib/runfile/dsl.rb
+++ b/lib/runfile/dsl.rb
@@ -63,8 +63,8 @@ module Runfile
   end
 
   # Cross-call another action
-  #   call 'other_action'
-  def call(command_string)
+  #   execute 'other_action'
+  def execute(command_string)
     Runner.instance.cross_call command_string
   end
 

--- a/lib/runfile/runner.rb
+++ b/lib/runfile/runner.rb
@@ -88,7 +88,7 @@ module Runfile
       end
     end
 
-    # Invoke action from another action. Used by the DSL's #call 
+    # Invoke action from another action. Used by the DSL's #execute 
     # function. Expects to get a single string that looks as if
     # it was typed in the command prompt.
     def cross_call(command_string) 


### PR DESCRIPTION
The method 'call` caused some conflicts, renamed it to `execute`

Fixes #16