### PR TITLE
Add option to prevent module inclusion for better isolation

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -5,6 +5,6 @@ require 'runfile'
 # for dev
 # require File.dirname(__FILE__) + "/../lib/runfile"
 
-include Runfile
+include Runfile unless File.exist? '.scoped-runfile'
 
-Runner.instance.execute ARGV
+Runfile::Runner.instance.execute ARGV

--- a/bin/run!
+++ b/bin/run!
@@ -5,7 +5,7 @@ require 'runfile'
 # for dev
 # require File.dirname(__FILE__) + "/../lib/runfile"
 
-include Runfile
+include Runfile unless File.exist? '.scoped-runfile'
 
 # This is needed in cases when you are running "run!" from a folder
 # that contains a Gemfile on a machine with RVM.
@@ -13,4 +13,4 @@ include Runfile
 # Source: https://rvm.io/integration/bundler
 ENV['NOEXEC_DISABLE'] = '1'
 
-Runner.instance.execute ARGV, false
+Runfile::Runner.instance.execute ARGV, false

--- a/examples/u_scoped_runfile/fail.runfile
+++ b/examples/u_scoped_runfile/fail.runfile
@@ -1,0 +1,15 @@
+# in this example we have also added the '.scoped-runfile' file.
+# this will prevent the `run` command from automatically including
+# the Runfile module which may cause namespace conflicts if your 
+# Runfile is more complex. 
+# when using this method, you need to `include Runfile` in your Runfile
+
+# This example will fail unless the next line is uncommented
+
+# include Runfile
+
+name 'Scoping Test'
+
+action :functional do
+  say "yes"
+end

--- a/examples/u_scoped_runfile/pass.runfile
+++ b/examples/u_scoped_runfile/pass.runfile
@@ -1,0 +1,13 @@
+# in this example we have also added the '.scoped-runfile' file.
+# this will prevent the `run` command from automatically including
+# the Runfile module which may cause namespace conflicts if your 
+# Runfile is more complex. 
+# when using this method, you need to `include Runfile` in your Runfile
+
+include Runfile
+
+name 'Scoping Test'
+
+action :functional do
+  say "yes"
+end

--- a/features/p_scoped.feature
+++ b/features/p_scoped.feature
@@ -1,0 +1,14 @@
+Feature: Scoped Runfile
+  In order to prevent conflicts with the Runfile DSL
+  Users can have a ".scoped-runfile" file in the current directory
+
+Background:
+  Given I am in the "examples/u_scoped_runfile" folder
+
+Scenario: Execute a runfile that includes the module
+   When I run "run pass functional"
+   Then the output should say "yes"
+
+Scenario: Execute a runfile that does not include the module
+   When I run "run fail"
+   Then the error output should match "undefined method .name. for main:Object"


### PR DESCRIPTION
In certain rare cases (for example when the Runfile is used in conjunction with ActiveRecord or Mongoid), some methods of the Runfile DSL (like `name`) may conflict with methods from other modules.

To overcome such a scenario, the user can now create an empty file named `.scoped-runfile` in the same directory as the `Runfile` file. This will prevent the `run` command from including the module, and the module will need to be included in the Runfile directly.

See the scoped example folder.
