### PR TITLE
Separate DSL to a submodule

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -5,6 +5,7 @@ require 'runfile'
 # for dev
 # require File.dirname(__FILE__) + "/../lib/runfile"
 
-include Runfile
+include Colsole
+include Runfile::DSL
 
-Runner.instance.execute ARGV
+Runfile::Runner.instance.execute ARGV

--- a/bin/run!
+++ b/bin/run!
@@ -5,7 +5,8 @@ require 'runfile'
 # for dev
 # require File.dirname(__FILE__) + "/../lib/runfile"
 
-include Runfile
+include Colsole
+include Runfile::DSL
 
 # This is needed in cases when you are running "run!" from a folder
 # that contains a Gemfile on a machine with RVM.
@@ -13,4 +14,4 @@ include Runfile
 # Source: https://rvm.io/integration/bundler
 ENV['NOEXEC_DISABLE'] = '1'
 
-Runner.instance.execute ARGV, false
+Runfile::Runner.instance.execute ARGV, false

--- a/lib/runfile/docopt_helper.rb
+++ b/lib/runfile/docopt_helper.rb
@@ -2,13 +2,12 @@ require 'docopt'
 require 'colsole'
 
 module Runfile
-  include Colsole
-
   # The DocoptHelper class handles the dynamic generation of the 
   # docopt document and the docopt part of the execution (meaning,
   # to call Docopt so it returns the parsed arguments or halts with
   # usage message).
   class DocoptHelper
+    include Colsole
 
     # The constructor expects to get all the textual details
     # needed to generate a docopt document (name, version, 

--- a/lib/runfile/dsl.rb
+++ b/lib/runfile/dsl.rb
@@ -3,119 +3,121 @@
 # for handling.
 
 module Runfile
-  private
+  module DSL
+    private
 
-  # Set the name of your Runfile program
-  #   name 'My Runfile'
-  def name(name)
-    Runner.instance.name = name
+    # Set the name of your Runfile program
+    #   name 'My Runfile'
+    def name(name)
+      Runner.instance.name = name
+    end
+
+    # Set the version of your Runfile program
+    #   version '0.1.0'
+    def version(ver)
+      Runner.instance.version = ver
+    end
+
+    # Set the one line summary of your Runfile program
+    #   summary 'Utilities for my server'
+    def summary(text)
+      Runner.instance.summary = text
+    end
+
+    # Set the usage pattern for the next action
+    #   usage 'server [--background]'
+    def usage(text)
+      Runner.instance.last_usage = text
+    end
+
+    # Set the help message for the next action
+    #   help 'Starts the server in the foreground or background'
+    def help(text)
+      Runner.instance.last_help = text
+    end
+
+    # Add an option/flag to the next action (can be called multiple
+    # times)
+    #   option '-b --background', 'Start in the background'
+    def option(flag, text, scope=nil)
+      Runner.instance.add_option flag, text, scope
+    end
+
+    # Set an example command (can be called multiple times)
+    #   example 'server --background'
+    def example(text)
+      Runner.instance.add_example text
+    end
+
+    # Define the action
+    #   action :server do |args|
+    #     run 'rails server'
+    #   end
+    def action(name, altname=nil, &block) 
+      Runner.instance.add_action name, altname, &block
+    end
+
+    # Define a new command namespace
+    #   command 'server'
+    #   # ... define actions here
+    #   endcommand
+    def command(name=nil)
+      Runner.instance.namespace = name
+    end
+
+    # Cross-call another action
+    #   execute 'other_action'
+    def execute(command_string)
+      Runner.instance.cross_call command_string
+    end
+
+    # Run a command, wait until it is done and continue
+    #   run 'rails server'
+    def run(*args)
+      ExecHandler.instance.run *args
+    end
+
+    # Run a command, wait until it is done, then exit
+    #   run! 'rails server'
+    def run!(*args)
+      ExecHandler.instance.run! *args
+    end
+
+    # Run a command in the background, optionally log to a log file and save
+    # the process ID in a pid file
+    #   run_bg 'rails server', pid: 'rails', log: 'tmp/log.log'
+    def run_bg(*args)
+      ExecHandler.instance.run_bg *args
+    end
+
+    # Stop a command started with 'run_bg'. Provide the name of he pid file you 
+    # used in 'run_bg'
+    #   stop_bg 'rails'
+    def stop_bg(*args)
+      ExecHandler.instance.stop_bg *args
+    end
+
+    # Set a block to be called before each run. The block should return
+    # the command to run, since this is intended to let the block modify
+    # the command if it needs to.
+    #   before_run do |command|
+    #     puts "BEFORE #{command}"
+    #     command
+    #   end
+    def before_run(&block)
+      ExecHandler.instance.before_run &block
+    end
+
+    # Set a block to be called after each run
+    #   before_run do |command|
+    #     puts "AFTER #{command}"
+    #   end
+    def after_run(&block)
+      ExecHandler.instance.after_run &block
+    end
+
+    # Also allow to use 'endcommand' instead of 'command' to end
+    # a command namespace definition
+    alias_method :endcommand, :command
   end
-
-  # Set the version of your Runfile program
-  #   version '0.1.0'
-  def version(ver)
-    Runner.instance.version = ver
-  end
-
-  # Set the one line summary of your Runfile program
-  #   summary 'Utilities for my server'
-  def summary(text)
-    Runner.instance.summary = text
-  end
-
-  # Set the usage pattern for the next action
-  #   usage 'server [--background]'
-  def usage(text)
-    Runner.instance.last_usage = text
-  end
-
-  # Set the help message for the next action
-  #   help 'Starts the server in the foreground or background'
-  def help(text)
-    Runner.instance.last_help = text
-  end
-
-  # Add an option/flag to the next action (can be called multiple
-  # times)
-  #   option '-b --background', 'Start in the background'
-  def option(flag, text, scope=nil)
-    Runner.instance.add_option flag, text, scope
-  end
-
-  # Set an example command (can be called multiple times)
-  #   example 'server --background'
-  def example(text)
-    Runner.instance.add_example text
-  end
-
-  # Define the action
-  #   action :server do |args|
-  #     run 'rails server'
-  #   end
-  def action(name, altname=nil, &block) 
-    Runner.instance.add_action name, altname, &block
-  end
-
-  # Define a new command namespace
-  #   command 'server'
-  #   # ... define actions here
-  #   endcommand
-  def command(name=nil)
-    Runner.instance.namespace = name
-  end
-
-  # Cross-call another action
-  #   execute 'other_action'
-  def execute(command_string)
-    Runner.instance.cross_call command_string
-  end
-
-  # Run a command, wait until it is done and continue
-  #   run 'rails server'
-  def run(*args)
-    ExecHandler.instance.run *args
-  end
-
-  # Run a command, wait until it is done, then exit
-  #   run! 'rails server'
-  def run!(*args)
-    ExecHandler.instance.run! *args
-  end
-
-  # Run a command in the background, optionally log to a log file and save
-  # the process ID in a pid file
-  #   run_bg 'rails server', pid: 'rails', log: 'tmp/log.log'
-  def run_bg(*args)
-    ExecHandler.instance.run_bg *args
-  end
-
-  # Stop a command started with 'run_bg'. Provide the name of he pid file you 
-  # used in 'run_bg'
-  #   stop_bg 'rails'
-  def stop_bg(*args)
-    ExecHandler.instance.stop_bg *args
-  end
-
-  # Set a block to be called before each run. The block should return
-  # the command to run, since this is intended to let the block modify
-  # the command if it needs to.
-  #   before_run do |command|
-  #     puts "BEFORE #{command}"
-  #     command
-  #   end
-  def before_run(&block)
-    ExecHandler.instance.before_run &block
-  end
-
-  # Set a block to be called after each run
-  #   before_run do |command|
-  #     puts "AFTER #{command}"
-  #   end
-  def after_run(&block)
-    ExecHandler.instance.after_run &block
-  end
-
-  # Also allow to use 'endcommand' instead of 'command' to end
-  # a command namespace definition
-  alias_method :endcommand, :command
 end

--- a/runfile.gemspec
+++ b/runfile.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-expectations', '~> 3.5'
   s.add_development_dependency 'rdoc', '~> 4.3'
   s.add_development_dependency 'similar_text', '~> 0.0.4'
+  s.add_development_dependency 'byebug', '~> 9.0'
 end

--- a/runfile.gemspec
+++ b/runfile.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_runtime_dependency 'colsole', '~> 0.3'
+  s.add_runtime_dependency 'colsole', '~> 0.4'
   s.add_runtime_dependency 'docopt', '~> 0.5'
 
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
-  s.add_development_dependency 'cucumber', '~> 2.3'
-  s.add_development_dependency 'rspec-expectations', '~> 3.4'
-  s.add_development_dependency 'rdoc', '~> 4.2'
+  s.add_development_dependency 'cucumber', '~> 2.4'
+  s.add_development_dependency 'rspec-expectations', '~> 3.5'
+  s.add_development_dependency 'rdoc', '~> 4.3'
   s.add_development_dependency 'similar_text', '~> 0.0.4'
 end


### PR DESCRIPTION
This is a maintenance PR, with these changes:

1. Move all the DSL commands to the submodule `Runfile::DSL`, for a cleaner `Runfile` namespace.
2. Remove `Colsole` from the global `Runfile` namespace.
3. Include `Colsole` and `Runfile::DSL` in the binary entrypoints.
4. Update gemspec dev dependency vesions