### PR TITLE
Change 'name' to 'title'

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -1,7 +1,7 @@
 require "runfile-tasks"
 require "yaml"
 
-name    "Runfile Runfile"
+title   "Runfile Runfile"
 summary "Runfile tasks for building the Runfile gem"
 version Runfile::VERSION
 

--- a/examples/b_basic/Runfile
+++ b/examples/b_basic/Runfile
@@ -1,5 +1,5 @@
 # define the application itself
-name    "Runner"
+title   "Runner"
 summary "The first ever Runfile program"
 version "0.1.0"
 

--- a/examples/c_documented/Runfile
+++ b/examples/c_documented/Runfile
@@ -3,8 +3,8 @@
 # each Runfile may have a summary and a version. Both are optional.
 #---
 
-# name sets the title of the application (default: 'Runfile').
-name "Runner"
+# title sets the title of the application (default: 'Runfile').
+title "Runner"
 
 # summary sets the one line description of the application.
 summary "The first ever Runfile program"

--- a/examples/s_settings/commands/beer.runfile
+++ b/examples/s_settings/commands/beer.runfile
@@ -1,4 +1,4 @@
-name    "Beer"
+title   "Beer"
 summary "A sample Runfile"
 
 action :drink do

--- a/examples/s_settings/commands/loadchecker.runfile
+++ b/examples/s_settings/commands/loadchecker.runfile
@@ -1,4 +1,4 @@
-name    "Load Checker"
+title   "Load Checker"
 summary "Test that our helper was loaded"
 
 action :check do

--- a/examples/s_settings/commands/pizza.runfile
+++ b/examples/s_settings/commands/pizza.runfile
@@ -1,4 +1,4 @@
-name    "Pizza"
+title   "Pizza"
 summary "A sample Runfile"
 
 action :order do

--- a/examples/s_settings/commands/server.runfile
+++ b/examples/s_settings/commands/server.runfile
@@ -1,4 +1,4 @@
-name    "Server"
+title   "Server"
 summary "A Sample Server"
 
 usage  "start [--daemon]"

--- a/lib/runfile/deprecations.rb
+++ b/lib/runfile/deprecations.rb
@@ -4,7 +4,7 @@ module Runfile
     # The name 'name' was causing some issues in some debugging sessions 
     # with pry and some other issues. It is replaced with 'title'
     def name(name=nil)
-      say! "!txtred!You are using the deprecated directive 'name' in your Runfile.\nUse 'title' instead"
+      say! "!txtred!Warning:\n  You are using the deprecated directive 'name' in your Runfile.\n  Use 'title' instead.\n"
       Runner.instance.name = name if name
     end
   end

--- a/lib/runfile/deprecations.rb
+++ b/lib/runfile/deprecations.rb
@@ -1,14 +1,11 @@
 module Runfile
 
-  # The Runfile::Exec module is derecated. It is kept here so that those
-  # who include it in the past will know what to do.
-  module Exec
-    def self.included(base)
-      say! "!txtred!Runfile::Exec is deprecated. You should change your Runfile:"
-      say! "!txtred!  1. There is no need to include Runfile::Exec, it is already included."
-      say! "!txtred!  2. Change any configuration from Runfile::Exec.pid_dir to Runfile.pid_dir"
-      abort
+  module DSL
+    # The name 'name' was causing some issues in some debugging sessions 
+    # with pry and some other issues. It is replaced with 'title'
+    def name(name=nil)
+      say! "!txtred!You are using the deprecated directive 'name' in your Runfile.\nUse 'title' instead"
+      Runner.instance.name = name if name
     end
   end
-
 end

--- a/lib/runfile/dsl.rb
+++ b/lib/runfile/dsl.rb
@@ -7,8 +7,8 @@ module Runfile
     private
 
     # Set the name of your Runfile program
-    #   name 'My Runfile'
-    def name(name)
+    #   title 'My Runfile'
+    def title(name)
       Runner.instance.name = name
     end
 

--- a/lib/runfile/templates/Runfile
+++ b/lib/runfile/templates/Runfile
@@ -1,4 +1,4 @@
-name    "Greeter"
+title   "Greeter"
 summary "A sample Runfile"
 version "0.1.0"
 

--- a/lib/runfile/version.rb
+++ b/lib/runfile/version.rb
@@ -1,3 +1,3 @@
 module Runfile
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/runfile.gemspec
+++ b/runfile.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-expectations', '~> 3.5'
   s.add_development_dependency 'rdoc', '~> 4.3'
   s.add_development_dependency 'similar_text', '~> 0.0.4'
-  s.add_development_dependency 'byebug', '~> 9.0'
+  s.add_development_dependency 'pry', '~> 0.10'
 end


### PR DESCRIPTION
Change the command `name` to `title`.

This change is long overdue, since the method global `name` is sometimes used by other contexts, and causes collisions (for example, when using `pry`).

Using `name` will still work for a while, but will print a deprecation warning to stderr.