### PR TITLE
Update colsole dependency

### DIFF
--- a/lib/runfile/version.rb
+++ b/lib/runfile/version.rb
@@ -1,3 +1,3 @@
 module Runfile
-  VERSION = "0.9.1"
+  VERSION = "0.10.0"
 end

--- a/runfile.gemspec
+++ b/runfile.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.0.0"
 
-  s.add_runtime_dependency 'colsole', '~> 0.4'
+  s.add_runtime_dependency 'colsole', '~> 0.5'
   s.add_runtime_dependency 'docopt', '~> 0.5'
 
   s.add_development_dependency 'runfile-tasks', '~> 0.4'


### PR DESCRIPTION
This PR updates the [Colsole][1] dependency to at least `0.5.0` in order to enjoy the better terminal width handling. Hopefully this resolves all issues when running in CI or in other weird terminals that refuse to report terminal size properly.

[1]: https://github.com/dannyben/colsole