### PR TITLE
Fix `run!` when using RVM in a Gemfiled folder

### DIFF
--- a/bin/run!
+++ b/bin/run!
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
 
+# This is needed in cases when you are running "run!" from a folder
+# that contains a Gemfile on a machine with RVM.
+# It will disable attempting to run in the current context
+# Source: https://rvm.io/integration/bundler
+ENV['NOEXEC_DISABLE'] = '1'
+
 require 'runfile'
 
 # for dev
@@ -7,11 +13,5 @@ require 'runfile'
 
 include Colsole
 include Runfile::DSL
-
-# This is needed in cases when you are running "run!" from a folder
-# that contains a Gemfile on a machine with RVM.
-# It will disable attempting to run in the current context
-# Source: https://rvm.io/integration/bundler
-ENV['NOEXEC_DISABLE'] = '1'
 
 Runfile::Runner.instance.execute ARGV, false


### PR DESCRIPTION
When using RVM, and trying to use `run!` in a folder with a `Gemfile`, Runfile exited with errors in some cases.

Moving `NOEXEC_DISABLE` to the top of the `run!` bin seems to make it better.