### PR TITLE
Add compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ Options:
 - [User Guide](https://runfile.dannyb.co/)
 - [Learn by Example](https://github.com/DannyBen/runfile/tree/master/examples#readme)
 
+## Breaking changes in 0.12.0
+
+Note that version 0.12.0 removes several commands from the DSL. 
+If you were using any of the Colsole commands (`say`, `resay`, etc.), or any of
+the `run`, `run_bg` commands, you will have to adjust your Runfile since they are
+no longer available.
+
+For convenience, you can simply `require runfile/compatibility` at the top of 
+your Runfile, to still have this functionality included.
+
+More info and alternative solutions in
+[this pull request](https://github.com/DannyBen/runfile/pull/46).
+
 ## Contributing / Support
 
 If you experience any issue, have a question or a suggestion, or if you wish

--- a/lib/runfile/compatibility.rb
+++ b/lib/runfile/compatibility.rb
@@ -1,0 +1,6 @@
+# This file provides a compatibility layer for version 0.12.0
+# Simply require 'runfile/compatibility' to have the same
+# Colsole methods (say, resay...) and ExecHandler methods (run, run_bg...)
+require 'colsole'
+include Colsole
+

--- a/lib/runfile/compatibility.rb
+++ b/lib/runfile/compatibility.rb
@@ -1,6 +1,84 @@
-# This file provides a compatibility layer for version 0.12.0
-# Simply require 'runfile/compatibility' to have the same
-# Colsole methods (say, resay...) and ExecHandler methods (run, run_bg...)
+# This file provides a compatibility layer for version 0.12.0 so that
+# all the Colsole methods (say, resay...) and ExecHandler methods
+# (run, run_bg...) are still available
+# Simply require 'runfile/compatibility' to have the same functionality
+# as older versions.
+#
+# Notes:
+# - You need to have the colsole gem installed
+# - Requiring this file also includes it (see the end of the file).
+# - This functinality will be removed in future versions
+# - More info: https://github.com/DannyBen/runfile/pull/46
 require 'colsole'
-include Colsole
 
+module Runfile
+  module Compatibilty
+    include Colsole
+
+    # Run a command, wait until it is done and continue
+    def run(cmd)
+      cmd = @before_run_block.call(cmd) if @before_run_block
+      return false unless cmd
+      say "!txtgrn!> #{cmd}" unless Runfile.quiet
+      system cmd
+      @after_run_block.call(cmd) if @after_run_block
+    end
+
+    # Run a command, wait until it is done, then exit
+    def run!(cmd)
+      cmd = @before_run_block.call(cmd) if @before_run_block
+      return false unless cmd
+      say "!txtgrn!> #{cmd}" unless Runfile.quiet
+      exec cmd
+    end
+
+    # Run a command in the background, optionally log to a log file and save
+    # the process ID in a pid file
+    def run_bg(cmd, pid: nil, log: '/dev/null')
+      cmd = @before_run_block.call(cmd) if @before_run_block
+      return false unless cmd
+      full_cmd = "exec #{cmd} >#{log} 2>&1"
+      say "!txtgrn!> #{full_cmd}" unless Runfile.quiet
+      process = IO.popen "exec #{cmd} >#{log} 2>&1"
+      File.write pidfile(pid), process.pid if pid
+      @after_run_block.call(cmd) if @after_run_block
+      return process.pid
+    end
+
+    # Stop a command started with 'run_bg'. Provide the name of he pid file you 
+    # used in 'run_bg'
+    def stop_bg(pid)
+      file = pidfile(pid)
+      if File.exist? file
+        pid = File.read file
+        File.delete file
+        run "kill -s TERM #{pid}"
+      else
+        say "!txtred!PID file not found." unless Runfile.quiet
+      end
+    end
+
+    # Set a block to be called before each run
+    def before_run(&block)
+      @before_run_block = block
+    end
+
+    # Set a block to be called after each run
+    def after_run(&block)
+      @after_run_block = block
+    end
+
+  private
+
+    def pid_dir
+      defined?(Runfile.pid_dir) ? Runfile.pid_dir : nil
+    end
+
+    def pidfile(pid)
+      pid_dir ? "#{pid_dir}/#{pid}.pid" : "#{pid}.pid"
+    end
+
+  end
+end
+
+include Runfile::Compatibilty


### PR DESCRIPTION
To ease the transition of the breaking change introduced in #46, anyone who can't let go of the `say` and `run` set of commands, can now add this to their Runfile to have the same functionality.

```ruby
require 'runfile/compatibility'
```

Note that this is a temporary fix, and this file will be removed in future versions. Se #46 for more details.