### PR TITLE
Update backtrace location report on error

### DIFF
--- a/lib/runfile/entrypoint.rb
+++ b/lib/runfile/entrypoint.rb
@@ -38,9 +38,7 @@ module Runfile
       1
     rescue => e
       allow_debug e
-      origin = e.backtrace_locations.first
-      location = "#{origin.path}:#{origin.lineno}"
-      say! "rib` #{e.class} ` in nu`#{location}`"
+      say! "rib` #{e.class} ` in nu`#{origin(e)}`"
       say! e.message
       say! "\nPrefix with nu`DEBUG=1` for full backtrace" unless ENV['DEBUG']
       1
@@ -53,6 +51,11 @@ module Runfile
 
       say! e.backtrace.reverse.join("\n")
       say! '---'
+    end
+
+    def origin(e)
+      (e.backtrace_locations&.first.to_s || e.backtrace&.first || 'unknown')
+        .tr '`', "'"
     end
 
     def rootfile

--- a/spec/approvals/bin/action-error
+++ b/spec/approvals/bin/action-error
@@ -1,4 +1,4 @@
-[7m[1m[31m ZeroDivisionError [0m in [4mrunfile:2[0m
+[7m[1m[31m ZeroDivisionError [0m in [4mrunfile:2:in '/'[0m
 divided by 0
 
 Prefix with [4mDEBUG=1[0m for full backtrace

--- a/spec/approvals/bin/syntax-error
+++ b/spec/approvals/bin/syntax-error
@@ -1,4 +1,4 @@
-[7m[1m[31m NameError [0m in [4mrunfile:1[0m
+[7m[1m[31m NameError [0m in [4mrunfile:1:in 'eval_code'[0m
 undefined local variable or method `nicely' for #<Runfile::Userfile name=nil, path="runfile">
 
 Prefix with [4mDEBUG=1[0m for full backtrace


### PR DESCRIPTION
In some cases, `backtrace_locations` returns `nil` on errors. This PR falls back to `backtrace` if this happens